### PR TITLE
Retry the connection in AbortHandler for any sync-exception

### DIFF
--- a/lib/Neptune/AbortHandler.hs
+++ b/lib/Neptune/AbortHandler.hs
@@ -3,6 +3,7 @@
 module Neptune.AbortHandler where
 
 import           Control.Lens          (_Right, (^?!))
+import           Control.Retry         (constantDelay, recoverAll)
 import           Data.Aeson            (FromJSON (..), Value (..),
                                         eitherDecode', (.:))
 import           Data.Aeson.Types      (prependFailure, typeMismatch)
@@ -38,10 +39,7 @@ abortListener sess exp main_thread = do
                 [("Authorization", "Bearer " <> encodeUtf8 oauth_token)]
                 (listener main_thread)
 
-    -- TODO reconnection
-    catch run_listener (\e -> do let msg = show (e :: SomeException)
-                                 traceShowM msg)
-
+    recoverAll (constantDelay 500) $ \_ -> run_listener
 
     where
         port       = 443

--- a/neptune-backend.cabal
+++ b/neptune-backend.cabal
@@ -66,6 +66,7 @@ library
     , websockets
     , wuss
     , unix
+    , retry
   other-modules:
       Paths_neptune_backend
   autogen-modules:


### PR DESCRIPTION
If any synchronous exception happens (likely happen for network issue in a very long job), we will constantly delay 0.5 seconds and reconnect to the notification endpoint to read more messages. 